### PR TITLE
wtfctf2021-mom5m4g1c: fix flag name

### DIFF
--- a/wtfctf2021/mom5m4g1c/.init
+++ b/wtfctf2021/mom5m4g1c/.init
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-ln -s /flag /challenge/flag.txt 2>/dev/null
+ln -s /flag /challenge/.flag.txt 2>/dev/null


### PR DESCRIPTION
The program mom5m4g1c runs `cat /challenge/.flag.txt` to print out the flag