### PR TITLE
wtfctf2021-mom5m4g1c: add challenge bin to sudoer 

### DIFF
--- a/wtfctf2021/mom5m4g1c/.init
+++ b/wtfctf2021/mom5m4g1c/.init
@@ -1,3 +1,8 @@
 #!/bin/bash
 
 ln -s /flag /challenge/.flag.txt 2>/dev/null
+
+echo "hacker ALL=(ALL:ALL) NOPASSWD: /challenge/mom5m4g1c" > /etc/sudoers.d/hacker
+
+chmod 0440 /etc/sudoers.d/hacker
+chmod 4755 /usr/bin/sudo

--- a/wtfctf2021/mom5m4g1c/DESCRIPTION.md
+++ b/wtfctf2021/mom5m4g1c/DESCRIPTION.md
@@ -1,5 +1,10 @@
 Son: I want my chocoloate mom!
 Mom: Fill the water bottel son! :)
 
+`Note: Use sudo to run the binary as:`
+```
+/bin/sudo /challenge/binary_name
+```
+
 ---
 **Author:** Pwnst4r5


### PR DESCRIPTION
The program mom5m4g1c print out the flag by calling `system`, which uses uid instead of eid, so it has no permission to cat out the flag. sudo is used as workaround.

Same reason as [angstromctf2018-rev1](https://github.com/pwncollege/ctf-archive/blob/main/angstromctf2018/rev1/.init)