### PR TITLE
fixing_shebang_and_RestrictedPython_search_path_for_uiuctf2023_pwn_500_rattler_read

### DIFF
--- a/uiuctf2023/rattler/main.py
+++ b/uiuctf2023/rattler/main.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python3
+#!/run/dojo/bin/exec-suid -- /usr/bin/python3
+
+import sys
+sys.path.append('/chroot/usr/local/lib/python3.8/site-packages')
 
 from RestrictedPython import compile_restricted
 from RestrictedPython import Eval


### PR DESCRIPTION
The challenge starts to the normal environment missing RestrictedPython and ignores the existing /chroot environment which is for ARM:
```
user@practice~uiuctf2023~pwn-500-rattler-read:~$ file /chroot/usr/local/bin/python3.8
/chroot/usr/local/bin/python3.8: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-aarch64.so.1, stripped
```
Its possible to use the RestrictedPython under /chroot/usr/local/lib/python3.8/site-packages.
With the exec-suid wrapper its possible to solve the challenge.
Closes #86 and #97.