### PR TITLE
Adding heap grooming to avoid non contiguous memory blocks

### DIFF
--- a/downunderctf2022/babypywn/babypywn
+++ b/downunderctf2022/babypywn/babypywn
@@ -2,6 +2,7 @@
 
 from ctypes import CDLL, c_buffer
 libc = CDLL('/usr/lib/x86_64-linux-gnu/libc.so.6')
+prime = [c_buffer(512) for _ in range(10)]
 buf1 = c_buffer(512)
 buf2 = c_buffer(512)
 libc.gets(buf1)


### PR DESCRIPTION
Under standard conditions the two blocks are not contiguous:
```
Address of buf1: 0x70f19a23c230
Address of buf2: 0x70f19a11f230
Distance: -1167360
```